### PR TITLE
Fix footer reset bug in reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,14 +141,16 @@
 
     function renderPage(index) {
       const page = pages[index];
+      const footer = document.getElementById('pageFooter');
+      if (index === pages.length - 1) {
+        footer.innerHTML = `by A.C. Van Cura — <a href="https://github.com/TheAVCfiles/Decrypt-The-Girl" target="_blank">GitHub</a> — <span id="pageIndicator"></span>`;
+      } else {
+        footer.innerHTML = 'by A.C. Van Cura — <span id="pageIndicator"></span>';
+      }
       document.getElementById('pageTitle').textContent = page.title;
       document.getElementById('pageSubtitle').textContent = page.subtitle;
       document.getElementById('pageContent').textContent = page.content;
       document.getElementById('pageIndicator').textContent = `Page ${index + 1} of ${pages.length}`;
-
-      if (index === pages.length - 1) {
-        document.getElementById('pageFooter').innerHTML = `by A.C. Van Cura — <a href="https://github.com/TheAVCfiles/Decrypt-The-Girl" target="_blank">GitHub</a>`;
-      }
     }
 
     function prevPage() {


### PR DESCRIPTION
## Summary
- maintain pageIndicator element across page transitions
- add GitHub link to footer only on last page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6859b53e6f7c8330b9fb9717137b5c23