### PR TITLE
Fix DOCTYPE and attempt remote fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- fix the missing `>` in the `DOCTYPE` declaration

## Testing
- `curl -L https://platform.openai.com/storage/vector_stores/vs_6859e43920848191a894dd36ecf0595a` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_b_685bbc0b867c83308aabad76f9f1e9ba