### PR TITLE
Add Founder Governance Studio playbook and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Experience the interactive codebook live:
 - **Astro Finance Guide**: [astro-finance.html](https://theavcfiles.github.io/Decrypt-The-Girl/astro-finance.html)
 - **Day Zero Scroll**: [day-zero-scroll.html](https://theavcfiles.github.io/Decrypt-The-Girl/day-zero-scroll.html)
 - **CROWN·SIGNAL·NODE v3**: [crown-signal-node.html](https://theavcfiles.github.io/Decrypt-The-Girl/crown-signal-node.html)
+- **Founder Governance Studio Playbook**: [docs/founder-governance-studio-playbook.md](docs/founder-governance-studio-playbook.md)
 
 ### CROWN·SIGNAL·NODE v3
 The CROWN console is a Firebase-ready signal room that respects the triadic ritual (Surface → Cipher → Echo) while maintaining a living CODA from the freshest transmission. It operates locally by default, caching signals in the browser and compressing the latest payload into a one-line seed.

--- a/docs/founder-governance-studio-playbook.md
+++ b/docs/founder-governance-studio-playbook.md
@@ -1,0 +1,158 @@
+# Founder Governance Studio Playbook
+
+This playbook converts pilot work into a repeatable operating sequence for outreach, applications, and paid engagements.
+
+## 1) Pilot Proof Pack (Phase I)
+
+Create one folder and keep all files versioned:
+
+```text
+PILOT_PROOF_PACK_SYVAQ_PHASEI/
+  A_OnePage_CaseStudy.pdf
+  B_Demo_Video_Link.txt
+  C_Offer_OnePager.pdf
+  Screenshots/
+```
+
+### Artifact A — One-page case study
+
+**Title:** `Governance Install: Pilot Deployment (Phase I)`
+
+Required sections:
+- Problem before install (no governance structure, no artefact trail, no compliance readiness).
+- Installed system after Phase I (diagrams, compliance memos, demo artefact, credit packet, sprint plan).
+- Deployment steps (short, procedural bullets).
+- Outcomes and acceptance criteria.
+- Optional one-line testimonial.
+
+### Artifact B — 90-second demo
+
+Demo checklist:
+- Open one live pilot artefact.
+- Show 2–3 core interactions.
+- Briefly show one architecture diagram.
+- Close with: `Phase I installs in 30 days.`
+
+### Artifact C — Offer one-pager
+
+**Title:** `Architecture Sprint / Governance Install (Fixed Scope)`
+
+Three-offer ladder:
+1. **Dossier Sprint** ($3k–$5k): docs + diagrams + credit packet.
+2. **Install Phase** ($7.5k): runnable deployment + handoff.
+3. **Institutional Pack** ($10k+): research framing + grant-ready bundle.
+
+Each offer must include:
+- Included deliverables.
+- Explicit exclusions.
+- Timeline.
+- Acceptance criteria.
+- Fixed-scope clause.
+
+## 2) Airlock Contract Language (use verbatim)
+
+```text
+Phase I concludes on schedule once deliverables are delivered.
+Phase II is optional and requires a separate agreement + payment.
+No scope expansion occurs without written amendment.
+```
+
+If communication becomes unstable, use procedural language:
+
+```text
+To keep delivery clean and on-time, communication stays inside the defined channels and scope. Phase I delivery remains on schedule.
+```
+
+## 3) Product Ladder and Packaging
+
+### Product tiers
+- **Founder Architecture Kit** ($149–$299): starter templates for early founders.
+- **Startup Dossier Kit** ($499): investor memo, technical roadmap, demo guide.
+- **Architecture Sprint** ($3k–$7k): done-for-you adaptation and consulting.
+- **Institutional Readiness Pack** ($10k+): grant-ready, research-oriented governance docs.
+
+### Template placeholders
+Use consistent placeholders for speed and quality control:
+- `[PROJECT_NAME]`
+- `[FOUNDER_NAME]`
+- `[PROBLEM_STATEMENT]`
+- `[TARGET_USERS]`
+- `[STACK]`
+- `[DEPLOYMENT_TARGET]`
+- `[COMPLIANCE_SCOPE]`
+
+## 4) Weekly Distribution Routine (No-begging pattern)
+
+Publish three lightweight proof signals each week:
+1. Architecture diagram snippet + one sentence outcome.
+2. 15–30 second demo clip.
+3. Template excerpt (for example: credit packet outline).
+
+Primary channels:
+- Founder channels: Indie Hackers, YC Startup School community, Product Hunt.
+- Professional channels: LinkedIn (founders, accelerator managers, innovation labs).
+- Builder communities: AI/developer Discord communities.
+
+Validation channels:
+- University labs and public-interest tech groups.
+- Women's safety and civic-tech accelerators.
+- Government innovation and grant programs.
+
+## 5) Startup Credits Application Packet
+
+Use one reusable packet for all applications:
+- Problem statement.
+- Architecture diagram.
+- Governance/compliance memo.
+- Pilot proof case study.
+- Credit usage plan by provider.
+
+Priority programs:
+- Google for Startups Cloud Program.
+- AWS Activate.
+- Microsoft for Startups Founders Hub.
+- NVIDIA Inception.
+- Twilio for Startups.
+- HubSpot for Startups.
+
+## 6) Business Structure and Safety
+
+Operational baseline:
+- Form an LLC and use a registered agent for address privacy.
+- Keep IP and operations separable if scaling into holdco/opco.
+- Keep all client work under fixed scope, fixed fee, and explicit exit criteria.
+
+Personal safety baseline:
+- Use privacy-preserving filing patterns.
+- Avoid publishing personal addresses in public records.
+- Maintain controlled communication channels in all contracts.
+
+## 7) 30-Day Execution Sprint
+
+### Week 1
+- Finalize Artifact A, B, C.
+- Collect 3–8 screenshots.
+- Request one brief founder testimonial.
+
+### Week 2
+- Publish a one-page storefront (site or Gumroad) with the 3 offer tiers.
+- Add demo clips and package summaries.
+
+### Week 3
+- Run founder outreach using the proof pack.
+- Target accelerators and lab operators with concise artefact-first messages.
+
+### Week 4
+- Submit startup credit applications with standardized packet.
+- Log responses and refine materials.
+
+## 8) Definition of Done for Phase I
+
+Phase I is complete when:
+- Proof pack is assembled and portable.
+- Offer page is public.
+- Outreach routine is active.
+- Applications are submitted.
+- Exit conditions are documented and enforceable.
+
+This keeps the architecture portable even if any single founder environment is volatile.


### PR DESCRIPTION
### Motivation
- Convert the pilot-to-proof strategy into a concise, deployable playbook so the repository contains an operational sequence for outreach, credit applications, and paid engagements.
- Surface that playbook from the project entrypoint so contributors and users can quickly find the artifact templates, airlock language, and 30-day sprint checklist.

### Description
- Add `docs/founder-governance-studio-playbook.md` with the Pilot Proof Pack structure, Artifact A/B/C templates, verbatim airlock contract language, product tiers, distribution cadence, startup-credit packet guidance, business/privacy notes, and a 30-day execution sprint.
- Update `README.md` to include a link to the new playbook under Available Experiences for easier discoverability.

### Testing
- Ran `npm test`, which runs `python3 -m json.tool chatbot.json` and `node tests/telemetry.test.js`, and the test suite completed successfully.
- Test result: `10 passed, 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa37bd70d4833091123325556d9865)